### PR TITLE
added https logging

### DIFF
--- a/lib/exaproxy/reactor/redirector/worker.py
+++ b/lib/exaproxy/reactor/redirector/worker.py
@@ -539,6 +539,7 @@ Encapsulated: req-hdr=0, null-body=%d
 
 				if not self.enabled:
 					self.respond(Respond.connect(client_id, message.host, message.port, http))
+					self.usage.logRequest(client_id, peer, method, message.url, 'PERMIT', message.host)
 					continue
 
 				(operation, destination), response = self.connect(client_id, *(self.classify(message,header,tainted)+(peer,header,source)))


### PR DESCRIPTION
I found exaproxy is not logging https requests. So I have copied one line from http request.

```
ExaProxy 29431  supervisor    Starting exaproxy version 1.1.2
ExaProxy 29431  supervisor    python version 2.7.5 (default, Feb 24 2014, 15:33:10)  [GCC 4.6.3 20120306 (Red Hat 4.6.3-2)]
ExaProxy 29431  usage         2014-03-01 03:23:24 1393644204.76 47 192.168.1.154 CONNECT www.google.com:443/ PERMIT/www.google.com
```
