### PR TITLE
Remove all traces of any proxy

### DIFF
--- a/etc/exaproxy/exaproxy.conf
+++ b/etc/exaproxy/exaproxy.conf
@@ -26,6 +26,7 @@ header-size = 65536
 idle-connect = 300
 proxied = false
 transparent = false
+mask = false
 
 [log]
 client = true

--- a/lib/exaproxy/application.py
+++ b/lib/exaproxy/application.py
@@ -146,6 +146,7 @@ def main ():
 			'connections'     : (value.integer,string.nop,'32768',   'the maximum number of proxy connections'),
 			'transparent'     : (value.boolean,string.lower,'false', 'do not reveal the presence of the proxy'),
 			'forward'         : (value.lowunquote,string.quote,'',   'read client address from this header (normally x-forwarded-for)'),
+			'mask'            : (value.boolean,string.lower,'false', 'hide client address by removing the header specified in exaproxy.http.forward'),
 			'allow-connect'   : (value.boolean,string.lower,'true',  'allow client to use CONNECT and https connections'),
 			'expect'          : (value.boolean,string.lower,'false', 'block messages with EXPECT headers with a 417'),
 			'extensions'      : (value.methods,string.list,'',       'allow new HTTP method (space separated)'),

--- a/lib/exaproxy/http/message.py
+++ b/lib/exaproxy/http/message.py
@@ -25,6 +25,7 @@ class HTTP (object):
 		self.client = remote_ip
 		self.proxy_name = "X-Proxy-Version: ExaProxy version %s" % configuration.proxy.version
 		self.forward = configuration.http.forward
+		self.mask = configuration.http.mask
 		self.log = Logger('header', configuration.log.header)
 		self.reply_code = 0
 		self.reply_string = ''
@@ -73,8 +74,8 @@ class HTTP (object):
 				#else:
 				#	self.log.info('Invalid address in Client identifier header: %s' % client)
 
-				# Remove x-forwarded-for when running in transparent mode
-				if transparent:
+				# Remove x-forwarded-for if exaproxy.http.mask is set
+				if self.mask:
 					self.headers.pop(self.forward, None)
 
 			# encoding can contain trailers and other information see RFC2516 section 14.39


### PR DESCRIPTION
The x-forwarded-for header should not be sent when running in transparent mode to conceal the fact that users are behind a proxy.
