### PR TITLE
Fix/check for worker

### DIFF
--- a/lib/exaproxy/reactor/redirector/manager.py
+++ b/lib/exaproxy/reactor/redirector/manager.py
@@ -189,7 +189,7 @@ class RedirectorManager (object):
 			if identifier in self.worker:
 				break
 			else:
-				self.log.warning("Worker %d was in available list, but it does not exist anymore" % identifier)
+				self.log.warning("Worker %s was in available list, but it does not exist anymore" % identifier)
 				identifier = None
 
 		if identifier != None:


### PR DESCRIPTION
There is a chance that a worker does not exist and this will lock the exaproxy process.
