### PR TITLE
Early return in options, handle missing response

### DIFF
--- a/lib/exaproxy/reactor/redirector/worker.py
+++ b/lib/exaproxy/reactor/redirector/worker.py
@@ -208,27 +208,21 @@ class Redirector:
 		# NOTE: we are always returning an HTTP/1.1 response
 		method = message.request.method
 
-		if message.headers.get('max-forwards',''):
-			max_forwards = message.headers.get('max-forwards','Max-Forwards: -1')[-1].split(':')[-1].strip()
-			max_forward = int(max_forwards) if max_forwards.isdigit() else None
-
-			if max_forward is None:
-				response = Respond.http(client_id, http('400', 'INVALID MAX-FORWARDS\n'))
+		max_forwards_header =  message.headers.get('max-forwards', False)
+		if max_forwards_header:
+			try:
+				max_forwards =int(max_forwards_header[-1].split(':')[-1].strip())
+			except ValueError: 
 				self.usage.logRequest(client_id, peer, method, message.url, 'ERROR', 'INVALID MAX FORWARDS')
+				return Respond.http(client_id, http('400', 'INVALID MAX-FORWARDS\n'))
 
-			elif max_forward == 0:
-				response = Respond.http(client_id, http('200', ''))
+			if max_forward == 0:
 				self.usage.logRequest(client_id, peer, method, message.url, 'PERMIT', method)
-
-			else:
-				response = None
+				return Respond.http(client_id, http('200', ''))
 
 			message.headers.set('max-forwards','Max-Forwards: %d' % (max_forward-1))
 
-		if response is None:
-			response = Respond.download(client_id, message.headerhost, message.port, message.upgrade, message.content_length, message)
-
-		return response
+		return Respond.download(client_id, message.headerhost, message.port, message.upgrade, message.content_length, message)
 
 	def doHTTP (self, client_id, peer, http_header, source):
 		message = self.parseHTTP(client_id, peer, http_header)


### PR DESCRIPTION
If `'max-forwards'` is not set in the headers, `response` is never assigned to.
