### PR TITLE
Always close a socket regardless of exceptions

### DIFF
--- a/lib/exaproxy/reactor/client/http.py
+++ b/lib/exaproxy/reactor/client/http.py
@@ -386,9 +386,10 @@ class HTTPClient (object):
 	def shutdown(self):
 		try:
 			self.sock.shutdown(socket.SHUT_RDWR)
-			self.sock.close()
 		except socket.error:
 			pass
+		finally:
+			self.sock.close()
 
 		self.writer.close()
 		self.reader.close()

--- a/lib/exaproxy/reactor/client/icap.py
+++ b/lib/exaproxy/reactor/client/icap.py
@@ -393,9 +393,10 @@ class ICAPClient (object):
 	def shutdown(self):
 		try:
 			self.sock.shutdown(socket.SHUT_RDWR)
-			self.sock.close()
 		except socket.error:
 			pass
+		finally:
+			self.sock.close()
 
 		self.writer.close()
 		self.reader.close()

--- a/lib/exaproxy/reactor/content/worker.py
+++ b/lib/exaproxy/reactor/content/worker.py
@@ -103,6 +103,7 @@ class Content (object):
 	def shutdown(self):
 		try:
 			self.sock.shutdown(socket.SHUT_RDWR)
-			self.sock.close()
 		except socket.error:
 			pass
+		finally:
+			self.sock.close()


### PR DESCRIPTION
This patch makes sure the socket is always closed. There are times `self.sock.shutdown()` raises `error: [Errno 107] Transport endpoint is not connected` which means the following line where the socket is closed, is skipped.
