### PR TITLE
Don't crash if getStats returns None

### DIFF
--- a/lib/exaproxy/monitor.py
+++ b/lib/exaproxy/monitor.py
@@ -119,7 +119,11 @@ class Monitor (object):
 		redirector = self._supervisor.redirector
 		reactor = self._supervisor.reactor
 
-		[redirector_stats] = redirector.getStats()
+		redirector_stats_output = redirector.getStats()
+		if redirector_stats_output == None:
+			return {}
+
+		[redirector_stats] = redirector_stats_output
 
 		return {
 			'pid.saved' : self._supervisor.pid._saved_pid,


### PR DESCRIPTION
Hi!

This patch fixes the following error:

Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/opt/exaproxy/lib/exaproxy/util/debug.py", line 71, in <module>
    execfile(sys.argv[0])
  File "/opt/exaproxy/lib/exaproxy/application.py", line 317, in <module>
    main()
  File "/opt/exaproxy/lib/exaproxy/application.py", line 280, in main
    Supervisor(configuration).run()
  File "/opt/exaproxy/lib/exaproxy/supervisor.py", line 300, in run
    self.monitor.second()
  File "/opt/exaproxy/lib/exaproxy/monitor.py", line 146, in second
    self.seconds.append(self.statistics())
  File "/opt/exaproxy/lib/exaproxy/monitor.py", line 122, in statistics
    [redirector_stats] = redirector.getStats()
TypeError: 'NoneType' object is not iterable
