### PR TITLE
Check for empty line in resolver files

### DIFF
--- a/lib/exaproxy/configuration.py
+++ b/lib/exaproxy/configuration.py
@@ -143,7 +143,7 @@ class value (object):
 		for resolver in paths:
 			if os.path.exists(resolver):
 				with open(resolver) as r:
-					if 'nameserver' in (line.strip().split(None,1)[0].lower() for line in r.readlines()):
+					if 'nameserver' in (line.strip().split(None,1)[0].lower() for line in r.readlines() if line.strip()):
 						return resolver
 		raise TypeError('resolv.conf can not be found (are you using DHCP without any network setup ?)')
 


### PR DESCRIPTION
exaproxy can't start if there is an empty line in /etc/resolv.conf or any other resolver file :

Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/opt/exaproxy/lib/exaproxy/util/debug.py", line 71, in <module>
    execfile(sys.argv[0])
  File "/opt/exaproxy/lib/exaproxy/application.py", line 306, in <module>
    main()
  File "/opt/exaproxy/lib/exaproxy/application.py", line 232, in main
    configuration = load('exaproxy',defaults,arguments['configuration'])
  File "/opt/exaproxy/lib/exaproxy/configuration.py", line 297, in load
    _config = _configuration(conf)
  File "/opt/exaproxy/lib/exaproxy/configuration.py", line 281, in _configuration
    configuration.setdefault(section,Store())[option] = convert(conf)
  File "/opt/exaproxy/lib/exaproxy/configuration.py", line 146, in resolver
    if 'nameserver' in (line.strip().split(None,1)[0].lower() for line in r.readlines()):
  File "/opt/exaproxy/lib/exaproxy/configuration.py", line 146, in <genexpr>
    if 'nameserver' in (line.strip().split(None,1)[0].lower() for line in r.readlines()):
IndexError: list index out of range

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exaproxy/38)
<!-- Reviewable:end -->
