### PR TITLE
Fix: handle passthrough connections in redirector

### DIFF
--- a/lib/exaproxy/reactor/client/manager.py
+++ b/lib/exaproxy/reactor/client/manager.py
@@ -103,7 +103,7 @@ class ClientManager (object):
 		self.byname[name] = sock
 
 		# watch for the opening data
-		self.poller.addReadSocket('read_client', client.sock)
+		#self.poller.addReadSocket('read_client', client.sock)
 
 		accept_addr, accept_port = client.getAcceptAddress()
 

--- a/lib/exaproxy/reactor/redirector/worker.py
+++ b/lib/exaproxy/reactor/redirector/worker.py
@@ -300,6 +300,9 @@ class Redirector (object):
 		return Respond.monitor(client_id, message.request.path)
 
 
+	def doPassthrough (self, client_id, accept_addr, accept_port, peer, header, source):
+		return Respond.intercept(client_id, accept_addr, accept_port, header)
+
 	def decide (self, client_id, accept_addr, accept_port, peer, header, subheader, source):
 		if self.checkChild():
 			if source == 'proxy':
@@ -311,7 +314,11 @@ class Redirector (object):
 			elif source == 'tls':
 				response = self.doTLS(client_id, accept_addr, accept_port, peer, header, source)
 
+			elif source == 'passthrough':
+				response = self.doPassthrough(client_id, accept_addr, accept_port, peer, header, source)
+
 			else:
+				self.log.warning('closing unsupported client %s' % (source))
 				response = Respond.hangup(client_id)
 
 		else:


### PR DESCRIPTION
Before this fix, the redirector workers could not handle passthrough connections and forced a 'close' action (exaproxy/reactor/redirector/worker.py).

In addition, even if they answer properly ('intercept', which creates a downloader), it arrives asynchronously. So the initial 'read_client' hook is not enabled because it may happen before a downloader is created and the initial data from the client is discarded (losing the HTTP request).

Please confirm if this fix could be avoided by other means, like proper configuration, or it is the expected behavior and should be fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exaproxy/48)
<!-- Reviewable:end -->
